### PR TITLE
Add support for reading images from URLs

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,35 +6,59 @@ import (
 	"image/gif"
 	"image/jpeg"
 	"image/png"
+	"io"
 	"log"
+	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/nfnt/resize"
 )
 
 func main() {
-	inPath := flag.String("in", "-", "input file, or - for stdin")
+	inPath := flag.String("in", "-", "input file, url, or - for stdin")
 	outPath := flag.String("out", "-", "output file, or - for stdout")
 	width := flag.Int("width", 0, "maximum width")
 	height := flag.Int("height", 0, "maximum height")
 
 	flag.Parse()
 
-	var input = os.Stdin
+	var input = io.Reader(os.Stdin)
 	if *inPath != "-" {
-		f, err := os.Open(*inPath)
+		parsedUrl, err := url.Parse(*inPath)
 		if err != nil {
-			log.Fatal(err)
+			f, err := os.Open(*inPath)
+			if err != nil {
+				log.Fatal(err)
+			}
+			input = f
+			defer f.Close()
+		} else {
+			switch parsedUrl.Scheme {
+			case "http", "https":
+				response, err := http.Get(parsedUrl.String())
+				if err != nil {
+					log.Fatal(err)
+				}
+				input = response.Body
+			case "":
+				f, err := os.Open(*inPath)
+				if err != nil {
+					log.Fatal(err)
+				}
+				input = f
+				defer f.Close()
+			default:
+				log.Fatalf("Unsupported URL scheme %s", parsedUrl.Scheme)
+			}
 		}
-		input = f
+
 	}
 
 	img, format, err := image.Decode(input)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	input.Close()
 
 	log.Printf("Resizing a %s to maximum %v x %v", format, *width, *height)
 

--- a/main.go
+++ b/main.go
@@ -27,12 +27,7 @@ func main() {
 	if *inPath != "-" {
 		parsedUrl, err := url.Parse(*inPath)
 		if err != nil {
-			f, err := os.Open(*inPath)
-			if err != nil {
-				log.Fatal(err)
-			}
-			input = f
-			defer f.Close()
+			log.Fatal(err)
 		} else {
 			switch parsedUrl.Scheme {
 			case "http", "https":


### PR DESCRIPTION
The `-in` option now supports three formats:
- `-` stdin
- `foo/bar.png` local file
- `http://placehold.it/400x400` remote file
