### PR TITLE
Add image interpolation method to options

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,21 +18,21 @@ import (
 	"github.com/nfnt/resize"
 )
 
+var interpolationFunctions = map[string]resize.InterpolationFunction{
+  "nearest": resize.NearestNeighbor,
+  "bicubic": resize.Bicubic,
+  "bilinear": resize.Bilinear,
+  "mitchell": resize.MitchellNetravali,
+  "lanczos2": resize.Lanczos2,
+  "lanczos3": resize.Lanczos3,
+}
+
 func main() {
 	inPath := flag.String("in", "-", "input file, url, or - for stdin")
 	outPath := flag.String("out", "-", "output file, or - for stdout")
 	interpolationFunction := flag.String("interpolation-function", "nearest", "interpolation function - 'nearest', 'bicubic', 'bilinear', 'mitchell', 'lanczos2', or 'lanzoc3'")
 	width := flag.Int("width", 0, "maximum width")
 	height := flag.Int("height", 0, "maximum height")
-
-  interpolationFunctions := map[string]resize.InterpolationFunction{
-    "nearest": resize.NearestNeighbor,
-    "bicubic": resize.Bicubic,
-    "bilinear": resize.Bilinear,
-    "mitchell": resize.MitchellNetravali,
-    "lanczos2": resize.Lanczos2,
-    "lanczos3": resize.Lanczos3,
-  }
 
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -21,8 +21,9 @@ import (
 func main() {
 	inPath := flag.String("in", "-", "input file, url, or - for stdin")
 	outPath := flag.String("out", "-", "output file, or - for stdout")
+	method := flag.String("method", "nearest", "image resize method - 'nearest', 'bicubic', 'bilinear', 'mitchell', 'lanczos2', or 'lanzoc3'")
 	width := flag.Int("width", 0, "maximum width")
-	height := flag.Int("height", 0, "maximum height")
+  height := flag.Int("height", 0, "maximum height")
 
 	flag.Parse()
 
@@ -75,9 +76,17 @@ func main() {
 		log.Fatal(err)
 	}
 
+  methods := make(map[string]resize.InterpolationFunction)
+  methods["nearest"] = resize.NearestNeighbor
+  methods["bicubic"] = resize.Bicubic
+  methods["bilinear"] = resize.Bilinear
+  methods["mitchell"] = resize.MitchellNetravali
+  methods["lanczos2"] = resize.Lanczos2
+  methods["lanczos3"] = resize.Lanczos3
+
 	log.Printf("Resizing a %s to maximum %v x %v", format, *width, *height)
 
-	resized := resize.Thumbnail(uint(*width), uint(*height), img, resize.Bicubic)
+	resized := resize.Thumbnail(uint(*width), uint(*height), img, methods[*method])
 
 	var output = os.Stdout
 	if *outPath != "-" {

--- a/main.go
+++ b/main.go
@@ -21,9 +21,9 @@ import (
 func main() {
 	inPath := flag.String("in", "-", "input file, url, or - for stdin")
 	outPath := flag.String("out", "-", "output file, or - for stdout")
-	method := flag.String("method", "nearest", "image resize method - 'nearest', 'bicubic', 'bilinear', 'mitchell', 'lanczos2', or 'lanzoc3'")
+	interpolationFunction := flag.String("interpolation-function", "nearest", "interpolation function - 'nearest', 'bicubic', 'bilinear', 'mitchell', 'lanczos2', or 'lanzoc3'")
 	width := flag.Int("width", 0, "maximum width")
-  height := flag.Int("height", 0, "maximum height")
+	height := flag.Int("height", 0, "maximum height")
 
 	flag.Parse()
 
@@ -76,17 +76,17 @@ func main() {
 		log.Fatal(err)
 	}
 
-  methods := make(map[string]resize.InterpolationFunction)
-  methods["nearest"] = resize.NearestNeighbor
-  methods["bicubic"] = resize.Bicubic
-  methods["bilinear"] = resize.Bilinear
-  methods["mitchell"] = resize.MitchellNetravali
-  methods["lanczos2"] = resize.Lanczos2
-  methods["lanczos3"] = resize.Lanczos3
+	interpolationFunctions := make(map[string]resize.InterpolationFunction)
+	interpolationFunctions["nearest"] = resize.NearestNeighbor
+	interpolationFunctions["bicubic"] = resize.Bicubic
+	interpolationFunctions["bilinear"] = resize.Bilinear
+	interpolationFunctions["mitchell"] = resize.MitchellNetravali
+	interpolationFunctions["lanczos2"] = resize.Lanczos2
+	interpolationFunctions["lanczos3"] = resize.Lanczos3
 
 	log.Printf("Resizing a %s to maximum %v x %v", format, *width, *height)
 
-	resized := resize.Thumbnail(uint(*width), uint(*height), img, methods[*method])
+	resized := resize.Thumbnail(uint(*width), uint(*height), img, interpolationFunctions[*interpolationFunction])
 
 	var output = os.Stdout
 	if *outPath != "-" {

--- a/main.go
+++ b/main.go
@@ -19,12 +19,12 @@ import (
 )
 
 var interpolationFunctions = map[string]resize.InterpolationFunction{
-  "nearest": resize.NearestNeighbor,
-  "bicubic": resize.Bicubic,
-  "bilinear": resize.Bilinear,
-  "mitchell": resize.MitchellNetravali,
-  "lanczos2": resize.Lanczos2,
-  "lanczos3": resize.Lanczos3,
+	"nearest":  resize.NearestNeighbor,
+	"bicubic":  resize.Bicubic,
+	"bilinear": resize.Bilinear,
+	"mitchell": resize.MitchellNetravali,
+	"lanczos2": resize.Lanczos2,
+	"lanczos3": resize.Lanczos3,
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -84,6 +84,10 @@ func main() {
 	interpolationFunctions["lanczos2"] = resize.Lanczos2
 	interpolationFunctions["lanczos3"] = resize.Lanczos3
 
+	if _, ok := interpolationFunctions[*interpolationFunction]; !ok {
+		log.Fatal("Invalid interpolation function provided.")
+	}
+
 	log.Printf("Resizing a %s to maximum %v x %v", format, *width, *height)
 
 	resized := resize.Thumbnail(uint(*width), uint(*height), img, interpolationFunctions[*interpolationFunction])

--- a/main.go
+++ b/main.go
@@ -25,6 +25,15 @@ func main() {
 	width := flag.Int("width", 0, "maximum width")
 	height := flag.Int("height", 0, "maximum height")
 
+  interpolationFunctions := map[string]resize.InterpolationFunction{
+    "nearest": resize.NearestNeighbor,
+    "bicubic": resize.Bicubic,
+    "bilinear": resize.Bilinear,
+    "mitchell": resize.MitchellNetravali,
+    "lanczos2": resize.Lanczos2,
+    "lanczos3": resize.Lanczos3,
+  }
+
 	flag.Parse()
 
 	var input = io.Reader(os.Stdin)
@@ -75,14 +84,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	interpolationFunctions := make(map[string]resize.InterpolationFunction)
-	interpolationFunctions["nearest"] = resize.NearestNeighbor
-	interpolationFunctions["bicubic"] = resize.Bicubic
-	interpolationFunctions["bilinear"] = resize.Bilinear
-	interpolationFunctions["mitchell"] = resize.MitchellNetravali
-	interpolationFunctions["lanczos2"] = resize.Lanczos2
-	interpolationFunctions["lanczos3"] = resize.Lanczos3
 
 	if _, ok := interpolationFunctions[*interpolationFunction]; !ok {
 		log.Fatal("Invalid interpolation function provided.")


### PR DESCRIPTION
Adds image methods as an option for the command under `-method`, along with changing the default image resize method to 'Nearest Neighbour'.

Fixes #3 
